### PR TITLE
Add setAll function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ dotProp.set(obj, 'foo.$end', 'platin-unicorn')
 
 ```
 
+### setAll
+
+Set multiple nested values by passing a map of path: value
+
+```javascript
+// Setter
+var obj = {foo: {bar: 'a'}};
+
+// var obj2 = dotProp.set(dotProp.set(obj, 'foo.bar', 'b') , 'foo.baz', 'x');
+var obj2 = dotProp.setAll(obj, {'foo.bar': 'b', 'foo.baz': 'x'});
+//obj2 => {foo: {bar: 'b', baz: 'x'}}
+```
 
 ### delete
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,17 @@ function set(obj, prop, value) {
 }
 
 /**
+ * Set many values defined in a map on the obj
+ * @param obj
+ * @param map
+ */
+function setAll(obj, map) {
+	return Object.keys(map).reduce(function (acc, path) {
+		return set(acc, path, map[path]);
+	}, obj);
+}
+
+/**
  * Get a value by a dot path.
  * @param obj The object to evaluate.
  * @param prop The path to value that should be returned.
@@ -163,6 +174,7 @@ function propToArray(prop) {
 
 module.exports = {
 	set: set,
+	setAll: setAll,
 	get: get,
 	delete: _delete,
 	toggle: toggle,

--- a/test/examples.spec.js
+++ b/test/examples.spec.js
@@ -129,21 +129,21 @@ describe('examples.spec.js', () => {
 		});
 	});
 
-	describe('when setMany', function () {
+	describe('when setMany', function() {
 
-		it('Sets a map of elements', function () {
-			expect(dotProp.setMany({foo: 0, bar: {baz: 1}}, {foo: 2, 'bar.baz': 3})).to.eql(
-				{foo: 2, bar: {baz: 3}}
+		it('Sets a map of elements', function() {
+			expect(dotProp.setMany({ foo: 0, bar: { baz: 1 } }, { foo: 2, 'bar.baz': 3 })).to.eql(
+				{ foo: 2, bar: { baz: 3 } }
 			);
 		});
 
-		it('Sets a map of elements un existent', function () {
-			expect(dotProp.setMany({}, {foo: 2, 'bar.baz': 3})).to.eql(
-				{foo: 2, bar: {baz: 3}}
+		it('Sets a map of elements un existent', function() {
+			expect(dotProp.setMany({}, { foo: 2, 'bar.baz': 3 })).to.eql(
+				{ foo: 2, bar: { baz: 3 } }
 			);
 		});
 	});
-	
+
 	describe('when delete', () => {
 
 		it('Array element by index', () => {

--- a/test/examples.spec.js
+++ b/test/examples.spec.js
@@ -125,6 +125,21 @@ describe('examples.spec.js', function() {
 		});
 	});
 
+	describe('when setAll', function () {
+
+		it('Sets a map of elements', function () {
+			expect(dotProp.setAll({foo: 0, bar: {baz: 1}}, {foo: 2, 'bar.baz': 3})).to.eql(
+				{foo: 2, bar: {baz: 3}}
+			);
+		});
+
+		it('Sets a map of elements un existent', function () {
+			expect(dotProp.setAll({}, {foo: 2, 'bar.baz': 3})).to.eql(
+				{foo: 2, bar: {baz: 3}}
+			);
+		});
+	});
+
 	describe('when delete', function() {
 
 		it('Array element by index', function() {


### PR DESCRIPTION
Useful when we need to change multiple properties at once.

This probably could be done on `set()` by accepting an object map to it.
