### PR TITLE
create new array if dot path is index and array doesn't exist in object

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ function getArrayIndex(theHead, obj) {
 	}
 	let newHead = parseInt(head, 10);
 	if (newHead < 0) { newHead = 0; }
-	if (newHead > obj.length) { newHead = obj.length; }
 	return newHead;
 }
 

--- a/index.js
+++ b/index.js
@@ -25,9 +25,14 @@ function propToArray(prop) {
 	}, []);
 }
 
+function isInt(str) {
+	const reg = /^\d+$/g;
+	return reg.test(str);
+}
+
 const setPropImmutableRec = (obj, prop, value, i) => {
-	let clone; let
-		head = prop[i];
+	let clone;
+	let head = prop[i];
 
 	if (prop.length > i) {
 		if (Array.isArray(obj)) {
@@ -37,15 +42,20 @@ const setPropImmutableRec = (obj, prop, value, i) => {
 			clone = Object.assign({}, obj);
 		}
 		if (obj[head] === undefined) {
-			if (!Number.isInteger(head)) {
-				clone[head] = setPropImmutableRec({}, prop, value, i + 1);
-			} else {
+			const blah = isInt(head);
+			if (blah) {
 				if (!Array.isArray(clone)) {
 					clone = [];
 				}
-				for (let x = clone.length - 1; x <= head; x += 1) {
-					clone.push((x === head ? setPropImmutableRec({}, prop, value, i + 1) : undefined));
+				if (clone.length > 0) {
+					for (let x = clone.length; x <= head; x += 1) {
+						clone.push((x === head ? setPropImmutableRec({}, prop, value, i + 1) : undefined));
+					}
+				} else {
+					clone.push(setPropImmutableRec({}, prop, value, i + 1));
 				}
+			} else {
+				clone[head] = setPropImmutableRec({}, prop, value, i + 1);
 			}
 		} else {
 			clone[head] = setPropImmutableRec(obj[head], prop, value, i + 1);
@@ -176,7 +186,7 @@ function del(obj, property) {
  * as "true" and "false" will toggle to false, but "0" will toggle to true.
  * Here is what Javascript considers false:
  * 0, -0, null, false, NaN, undefined, and the empty string ("")
- * @param obj The object to evaluate.s
+ * @param obj The object to evaluate.
  * @param prop The path to the value.
  */
 function toggle(obj, prop) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const setPropImmutableRec = (obj, prop, value, i) => {
 
 	if (prop.length > i) {
 		if (Array.isArray(obj)) {
-			head = getArrayIndex(head, obj);
+			head = Number(head);
 			clone = obj.slice();
 		} else {
 			clone = Object.assign({}, obj);

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const setPropImmutableRec = (obj, prop, value, i) => {
 			head = getArrayIndex(head, obj);
 			clone = obj.slice();
 		} else {
-			clone = { ...obj };
+			clone = Object.assign({}, obj);
 		}
 		if (obj[head] === undefined) {
 			if (!Number.isInteger(head)) {
@@ -136,7 +136,7 @@ const deletePropImmutableRec = (obj, prop, i) => {
 			head = getArrayIndex(head, obj);
 			clone = obj.slice();
 		} else {
-			clone = { ...obj };
+			clone = Object.assign({}, obj);
 		}
 
 		clone[head] = deletePropImmutableRec(obj[head], prop, i + 1);
@@ -147,7 +147,7 @@ const deletePropImmutableRec = (obj, prop, i) => {
 		head = getArrayIndex(head, obj);
 		clone = [].concat(obj.slice(0, head), obj.slice(head + 1));
 	} else {
-		clone = { ...obj };
+		clone = Object.assign({}, obj);
 		delete clone[head];
 	}
 
@@ -202,7 +202,7 @@ function merge(obj, prop, val) {
 			return set(obj, prop, val);
 		}
 
-		const merged = { ...curVal, ...val };
+		const merged = Object.assign({}, curVal, val);
 		return set(obj, prop, merged);
 	} if (typeof curVal === 'undefined') {
 		return set(obj, prop, val);

--- a/index.js
+++ b/index.js
@@ -226,5 +226,5 @@ module.exports = {
 	get,
 	delete: del,
 	toggle,
-	merge,
+	merge
 };


### PR DESCRIPTION
so, I've been using dot-prop-immutable in my web application and i love it but it doesn't create an array in the set method if the dot path has an array index and the array doesn't already exist in the object that's being modified. i'd love to add the feature if it is desired. thanks.